### PR TITLE
Fix compilation error with env::current_dir()

### DIFF
--- a/src/modules.rs
+++ b/src/modules.rs
@@ -223,7 +223,7 @@ pub fn format_module_git<'a>(c: &mut Config,
 
     let mut output = String::new();
 
-    if let Ok(repo) = Repository::discover(env::current_dir().unwrap_or_default()) {
+    if let Ok(repo) = Repository::discover(env::current_dir().unwrap()) {
         let local = repo.head().unwrap();
 
         // Output current branch name


### PR DESCRIPTION
changed 'env::current_dir().unwrap_or_default()' to 'env::current_dir().unwrap()'